### PR TITLE
Update div selector + mousetrap

### DIFF
--- a/romaja-lyrics/romaja_lyrics.js
+++ b/romaja-lyrics/romaja_lyrics.js
@@ -12,7 +12,7 @@ class Korean_Translator {
 
 class Romaja_Lyrics
 {
-    static LYRIC_DIV_SELECTOR = "div.lyrics-lyricsContent-lyric";
+    static LYRIC_DIV_SELECTOR = ".BXlQFspJp_jq9SKhUSP3";
     static translator = new Korean_Translator();
     static translated_lyrics = null;
     static original_lyrics = null;
@@ -34,7 +34,7 @@ class Romaja_Lyrics
 
     static addControlUI()
     {
-        const trap = new Spicetify.Mousetrap();
+        const trap = new Mousetrap();
         trap.handleKey = (character, modifiers, e) => {
 			if (e.type == "keydown") {
 				if(character == "tab" && modifiers.includes("ctrl"))

--- a/romaji-lyrics/marketplace/romaji_lyrics.js
+++ b/romaji-lyrics/marketplace/romaji_lyrics.js
@@ -73,7 +73,7 @@ class JapaneseTranslator {
 
 class Romaji_Lyrics
 {
-    static LYRIC_DIV_SELECTOR = "div.lyrics-lyricsContent-lyric";
+    static LYRIC_DIV_SELECTOR = ".BXlQFspJp_jq9SKhUSP3";
     static translator = new JapaneseTranslator();
     static translated_lyrics = null;
     static original_lyrics = null;
@@ -95,7 +95,7 @@ class Romaji_Lyrics
 
     static addControlUI()
     {
-        const trap = new Spicetify.Mousetrap();
+        const trap = new Mousetrap();
         trap.handleKey = (character, modifiers, e) => {
 			if (e.type == "keydown") {
 				if(character == "tab" && modifiers.includes("ctrl"))


### PR DESCRIPTION
I don't have much knowledge on how spotify works so I don't know is the div class name for lyrics permanent or it changes per update but for now it works. 

Also "spicetify.Mousetrap();" doesn't work while just "Mousetrap();" works, in official plugins it still uses spicetify.Mousetrap(); so idk why. 